### PR TITLE
docs: add llms.txt and llms-full.txt for LLM-friendly documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install mkdocs-material pymdown-extensions
+      - name: Generate llms-full.txt
+        run: python scripts/generate_llms_full.py
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,984 @@
+# sqlalchemy-pytibero
+
+[![PyPI](https://img.shields.io/pypi/v/sqlalchemy-pytibero)](https://pypi.org/project/sqlalchemy-pytibero/)
+[![Python](https://img.shields.io/pypi/pyversions/sqlalchemy-pytibero)](https://pypi.org/project/sqlalchemy-pytibero/)
+[![License](https://img.shields.io/pypi/l/sqlalchemy-pytibero)](https://github.com/yeongseon/sqlalchemy-pytibero/blob/main/LICENSE)
+
+`sqlalchemy-pytibero` is a SQLAlchemy 2.0 dialect for Tibero built on top of the `pytibero` DB-API driver. It provides SQL compilation, schema reflection, Tibero-specific type handling, and dialect integration for both Core and ORM usage.
+
+## Why this project
+
+- Registers the `tibero` SQLAlchemy dialect and `tibero.pytibero` driver name.
+- Provides Tibero-aware SQL and DDL compilers.
+- Maps Tibero column metadata to SQLAlchemy types for reflection.
+- Supports Tibero-compatible schema comments and identity columns.
+- Keeps the integration lightweight while following SQLAlchemy conventions.
+
+## Quick install
+
+```bash
+pip install sqlalchemy-pytibero
+pip install "sqlalchemy-pytibero[pytibero]"
+```
+
+## Quick usage
+
+```python
+from sqlalchemy import create_engine, text
+
+engine = create_engine("tibero://tibero:password@localhost:8629/TESTDB")
+with engine.connect() as conn:
+    print(conn.execute(text("SELECT 1 FROM DUAL")).scalar())
+```
+
+## Architecture
+
+```mermaid
+flowchart TD
+    app["Application"] --> sa["SQLAlchemy Core/ORM"]
+    sa --> dialect["TiberoDialect"]
+    dialect --> compiler["SQL/DDL/Type Compilers"]
+    dialect --> dbapi["pytibero"]
+    compiler --> sql["Tibero SQL"]
+    dbapi --> server["Tibero Server"]
+    sql --> server
+```
+
+## Documentation map
+
+### Getting Started
+
+- [Quick Start](quickstart.md)
+- [Connection Guide](connection.md)
+
+### User Guide
+
+- [Dialect Features](dialect-features.md)
+- [Type Mapping](types.md)
+- [Schema Reflection](reflection.md)
+- [DDL Generation](ddl.md)
+- [Limitations](limitations.md)
+
+### Reference and Development
+
+- [API Reference](api-reference.md)
+- [Development Guide](development.md)
+
+## Project links
+
+- GitHub: https://github.com/yeongseon/sqlalchemy-pytibero
+- PyPI: https://pypi.org/project/sqlalchemy-pytibero/
+
+---
+
+# Quick Start
+
+This guide gets `sqlalchemy-pytibero` running quickly with both SQLAlchemy Core and ORM.
+
+## Install
+
+```bash
+pip install sqlalchemy-pytibero
+```
+
+Optional: install with driver extra.
+
+```bash
+pip install "sqlalchemy-pytibero[pytibero]"
+```
+
+## Connection URL
+
+Use the Tibero dialect name:
+
+```text
+tibero://user:pass@host:port/db
+```
+
+Defaults from `TiberoDialect.create_connect_args()`:
+
+- `host`: `localhost`
+- `port`: `8629`
+- `user`: `tibero`
+- `password`: empty string
+- `database`: empty string
+
+## SQLAlchemy Core example
+
+```python
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, select
+
+engine = create_engine("tibero://tibero:password@localhost:8629/TESTDB", echo=True)
+metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", String(100), nullable=False),
+)
+
+metadata.create_all(engine)
+
+with engine.begin() as conn:
+    conn.execute(users.insert(), [{"name": "alice"}, {"name": "bob"}])
+
+with engine.connect() as conn:
+    rows = conn.execute(select(users.c.id, users.c.name)).all()
+    for row in rows:
+        print(row)
+```
+
+## SQLAlchemy ORM example
+
+```python
+from sqlalchemy import Integer, String, create_engine, select
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Account(Base):
+    __tablename__ = "account"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+
+
+engine = create_engine("tibero://tibero:password@localhost:8629/TESTDB")
+Base.metadata.create_all(engine)
+
+with Session(engine) as session:
+    session.add(Account(name="first"))
+    session.commit()
+
+    account = session.scalar(select(Account).where(Account.name == "first"))
+    account.name = "updated"
+    session.commit()
+
+    session.delete(account)
+    session.commit()
+```
+
+## Architecture
+
+```mermaid
+flowchart LR
+    app[Application Code] --> sa[SQLAlchemy Core / ORM]
+    sa --> dialect[sqlalchemy-pytibero\nTiberoDialect]
+    dialect --> dbapi[pytibero DB-API]
+    dbapi --> tibero[Tibero Database]
+```
+
+!!! warning "Driver import error"
+    `TiberoDialect.import_dbapi()` imports `pytibero` directly. If `pytibero` is missing, engine creation fails immediately.
+
+!!! tip "Start simple"
+    Validate connectivity first with `SELECT 1 FROM DUAL` before creating metadata and running migrations.
+
+!!! note "No RETURNING support"
+    `insert_returning`, `update_returning`, and `delete_returning` are disabled in this dialect. See [Limitations](limitations.md).
+
+---
+
+# Connection Guide
+
+This page documents how SQLAlchemy URLs are interpreted by `TiberoDialect.create_connect_args()` and how to configure engine/pool behavior.
+
+## URL format
+
+```text
+tibero://user:password@host:port/database
+```
+
+Examples:
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine("tibero://tibero:password@localhost:8629/TESTDB")
+engine_defaulted = create_engine("tibero://@localhost/")  # user/port/database defaulting applied
+```
+
+## URL default values
+
+When fields are omitted, the dialect applies:
+
+| Field | Default |
+|---|---|
+| host | `localhost` |
+| port | `8629` |
+| user | `tibero` |
+| password | `""` |
+| database | `""` |
+
+## `create_engine()` options
+
+Common SQLAlchemy options for Tibero workloads:
+
+```python
+engine = create_engine(
+    "tibero://tibero:password@db-host:8629/TESTDB",
+    echo=False,
+    pool_pre_ping=True,
+    pool_size=10,
+    max_overflow=20,
+    pool_timeout=30,
+    pool_recycle=1800,
+    isolation_level="READ COMMITTED",  # supported: READ COMMITTED, SERIALIZABLE
+)
+```
+
+`TiberoDialect.on_connect()` sets `autocommit=False` for each new DB-API connection.
+
+## Query parameters
+
+`create_connect_args()` uses translated URL parts (`host`, `port`, `database`, `user`, `password`) and does not consume custom query-string parameters itself. SQLAlchemy-level options should usually be passed directly to `create_engine(...)`.
+
+## Connection flow
+
+```mermaid
+flowchart TD
+    u[SQLAlchemy URL] --> p[translate_connect_args]
+    p --> d[TiberoDialect.create_connect_args]
+    d --> k[kwargs: host/port/database/user/password]
+    k --> drv[pytibero.connect(...)]
+    drv --> c[on_connect: autocommit=False]
+    c --> db[Tibero Session]
+```
+
+!!! warning "Isolation level validation"
+    `set_isolation_level()` only accepts `READ COMMITTED` and `SERIALIZABLE`. Any other value raises `ValueError`.
+
+!!! note "Disconnect detection"
+    `is_disconnect()` checks known message fragments and common Tibero/Oracle-like connection error codes for pool invalidation.
+
+!!! tip "Use pool_pre_ping"
+    For long-lived applications, `pool_pre_ping=True` helps recover stale connections by issuing a lightweight `SELECT 1 FROM DUAL` check.
+
+---
+
+# Dialect Features
+
+This page summarizes capability flags and SQL behaviors implemented by `TiberoDialect`, `TiberoCompiler`, and `TiberoDDLCompiler`.
+
+## Core capability flags
+
+| Feature | Value |
+|---|---|
+| `supports_statement_cache` | `True` |
+| `supports_sequences` | `True` |
+| `sequences_optional` | `True` |
+| `supports_comments` | `True` |
+| `inline_comments` | `False` |
+| `supports_alter` | `True` |
+| `supports_native_decimal` | `True` |
+| `supports_native_boolean` | `False` |
+| `supports_native_enum` | `False` |
+| `supports_default_values` | `False` |
+| `supports_default_metavalue` | `False` |
+| `supports_empty_insert` | `False` |
+| `supports_multivalues_insert` | `True` |
+| `supports_is_distinct_from` | `False` |
+| `insert_returning` | `False` |
+| `update_returning` | `False` |
+| `delete_returning` | `False` |
+
+## Isolation levels
+
+Supported values from `get_isolation_level_values()`:
+
+- `READ COMMITTED`
+- `SERIALIZABLE`
+
+`on_connect()` sets `conn.autocommit = False` and applies configured isolation level when provided.
+
+## Identity columns
+
+`TiberoDDLCompiler.get_column_specification()` emits identity syntax for SQLAlchemy autoincrement primary-key columns without explicit server default:
+
+```sql
+GENERATED ALWAYS AS IDENTITY
+```
+
+## LIMIT/OFFSET
+
+`TiberoCompiler.limit_clause()` uses ANSI-style pagination:
+
+- offset only: `OFFSET <n> ROWS`
+- limit only: `FETCH FIRST <n> ROWS ONLY`
+- both: `OFFSET <n> ROWS FETCH FIRST <m> ROWS ONLY`
+
+## Feature matrix
+
+```mermaid
+flowchart LR
+    subgraph Supported
+      seq[Sequences]
+      comments[Table/Column Comments]
+      alter[ALTER support]
+      multi[Multi-values INSERT]
+      identity[Identity Columns]
+    end
+    subgraph Not_Supported
+      returning[INSERT/UPDATE/DELETE RETURNING]
+      native_bool[Native BOOLEAN]
+      native_enum[Native ENUM]
+      empty_insert[Empty INSERT]
+      is_distinct[IS DISTINCT FROM]
+    end
+```
+
+!!! warning "No RETURNING support"
+    ORM patterns that depend on SQL `RETURNING` need alternatives (follow-up `SELECT`, sequence usage, or relying on DB-API `lastrowid` when available).
+
+!!! note "BOOLEAN handling"
+    `TiberoTypeCompiler.visit_BOOLEAN()` compiles to `NUMBER(1)`.
+
+!!! tip "Comments are out-of-line"
+    Comments are emitted via separate `COMMENT ON ...` statements because `inline_comments` is disabled.
+
+---
+
+# Type Mapping
+
+`sqlalchemy-pytibero` provides Tibero-specific type classes and compilers for DDL generation and reflection.
+
+## Exported Tibero type classes
+
+- `NUMBER`
+- `NUMERIC`
+- `DECIMAL`
+- `FLOAT`
+- `BINARY_FLOAT`
+- `BINARY_DOUBLE`
+- `SMALLINT`
+- `INTEGER`
+- `BIGINT`
+- `VARCHAR2`
+- `CHAR`
+- `NCHAR`
+- `NVARCHAR2`
+- `CLOB`
+- `BLOB`
+- `NCLOB`
+- `DATE`
+- `TIMESTAMP`
+- `INTERVAL_YEAR_TO_MONTH`
+- `INTERVAL_DAY_TO_SECOND`
+- `RAW`
+- `LONG_RAW`
+- `LONG`
+- `ROWID`
+
+## Reflection mapping (`ischema_names`)
+
+The dialect maps reflected Tibero type names to SQLAlchemy type classes:
+
+| Reflected Tibero type | Mapped class |
+|---|---|
+| NUMBER | `NUMBER` |
+| NUMERIC | `NUMERIC` |
+| DECIMAL | `DECIMAL` |
+| FLOAT | `FLOAT` |
+| BINARY_FLOAT | `BINARY_FLOAT` |
+| BINARY_DOUBLE | `BINARY_DOUBLE` |
+| SMALLINT | `SMALLINT` |
+| INTEGER | `INTEGER` |
+| INT | `INTEGER` |
+| BIGINT | `BIGINT` |
+| VARCHAR2 | `VARCHAR2` |
+| VARCHAR | `VARCHAR2` |
+| CHAR | `CHAR` |
+| NCHAR | `NCHAR` |
+| NVARCHAR2 | `NVARCHAR2` |
+| CLOB | `CLOB` |
+| NCLOB | `NCLOB` |
+| BLOB | `BLOB` |
+| DATE | `DATE` |
+| TIMESTAMP | `TIMESTAMP` |
+| RAW | `RAW` |
+| LONG RAW | `LONG_RAW` |
+| LONG | `LONG` |
+| ROWID | `ROWID` |
+| INTERVAL YEAR TO MONTH | `INTERVAL_YEAR_TO_MONTH` |
+| INTERVAL DAY TO SECOND | `INTERVAL_DAY_TO_SECOND` |
+
+## Type compiler behavior (`TiberoTypeCompiler`)
+
+Selected compilation rules:
+
+- `BOOLEAN` -> `NUMBER(1)`
+- `BIGINT` -> `NUMBER(19)`
+- `VARCHAR` -> `VARCHAR2`
+- `NVARCHAR` -> `NVARCHAR2`
+- `LargeBinary` -> `BLOB`
+- `Text` -> `CLOB`
+- `DateTime` -> `DATE`
+
+## Tibero to SQLAlchemy to Python mapping
+
+| Tibero Type | SQLAlchemy Type Class | Typical Python Type |
+|---|---|---|
+| NUMBER(p,s) | `NUMBER` / `NUMERIC` / `DECIMAL` | `decimal.Decimal` |
+| FLOAT / BINARY_FLOAT / BINARY_DOUBLE | `FLOAT` / `BINARY_FLOAT` / `BINARY_DOUBLE` | `float` |
+| SMALLINT / INTEGER / BIGINT | `SMALLINT` / `INTEGER` / `BIGINT` | `int` |
+| VARCHAR2 / CHAR / NCHAR / NVARCHAR2 | `VARCHAR2` / `CHAR` / `NCHAR` / `NVARCHAR2` | `str` |
+| CLOB / LONG | `CLOB` / `LONG` | `str` |
+| NCLOB | `NCLOB` | `str` |
+| BLOB / RAW / LONG RAW | `BLOB` / `RAW` / `LONG_RAW` | `bytes` |
+| DATE / TIMESTAMP | `DATE` / `TIMESTAMP` | `datetime.date` / `datetime.datetime` |
+| INTERVAL YEAR TO MONTH | `INTERVAL_YEAR_TO_MONTH` | driver-dependent |
+| INTERVAL DAY TO SECOND | `INTERVAL_DAY_TO_SECOND` | driver-dependent |
+| ROWID | `ROWID` | driver-dependent |
+
+## Resolution flow
+
+```mermaid
+flowchart TD
+    rt[Reflected DATA_TYPE] --> lookup[ischema_names lookup]
+    lookup --> known{Known type?}
+    known -- no --> nulltype[sqltypes.NULLTYPE + warning]
+    known -- yes --> args[Apply length/precision/scale rules]
+    args --> obj[Instantiate Tibero type class]
+    obj --> ddl[TiberoTypeCompiler emits DDL]
+```
+
+!!! warning "Unknown reflected types"
+    `_resolve_column_type()` emits `sqltypes.NULLTYPE` and a warning for unknown type names.
+
+!!! note "National character types"
+    `NCHAR` and `NVARCHAR2` set `national=True` in constructors.
+
+!!! tip "RAW length"
+    `RAW(length=...)` preserves explicit byte length and compiles as `RAW(<length>)`.
+
+---
+
+# Schema Reflection
+
+`TiberoDialect` implements a broad set of SQLAlchemy reflection hooks against Tibero system views.
+
+## Schema normalization
+
+- Effective schema is derived by `_effective_schema(connection, schema)`.
+- If `schema` is provided, uppercase is used.
+- If omitted, current schema is read with:
+
+```sql
+SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM DUAL
+```
+
+The dialect also enables SQLAlchemy name normalization (`requires_name_normalize = True`).
+
+## Table and view reflection
+
+### `get_table_names(connection, schema=None, **kw)`
+
+- With schema: reads `all_tables`
+- Without schema: reads `user_tables`
+
+### `get_view_names(connection, schema=None, **kw)`
+
+Reads `all_views` for the effective schema.
+
+### `get_view_definition(connection, view_name, schema=None, **kw)`
+
+Returns `text` from `all_views` for one view, or `None`.
+
+### `get_table_comment(connection, table_name, schema=None, **kw)`
+
+Returns `{ "text": <comment-or-None> }` from `all_tab_comments`.
+
+## Column reflection
+
+### `get_columns(connection, table_name, schema=None, **kw)`
+
+Reads:
+
+- `column_name`
+- `data_type`
+- `data_length`
+- `data_precision`
+- `data_scale`
+- `nullable`
+- `data_default`
+
+Type resolution is delegated to `_resolve_column_type(...)` using `ischema_names`.
+
+Example:
+
+```python
+from sqlalchemy import create_engine, inspect
+
+engine = create_engine("tibero://tibero:password@localhost:8629/TESTDB")
+insp = inspect(engine)
+print(insp.get_columns("USERS"))
+```
+
+## Constraint and index reflection
+
+### Primary key
+
+`get_pk_constraint(connection, table_name, schema=None, **kw)` returns:
+
+```python
+{"name": "PK_USERS", "constrained_columns": ["ID"]}
+```
+
+### Foreign keys
+
+`get_foreign_keys(connection, table_name, schema=None, **kw)` groups rows by constraint name and returns constrained/referred columns in order.
+
+### Indexes
+
+`get_indexes(connection, table_name, schema=None, **kw)` returns dictionaries with:
+
+- `name`
+- `column_names`
+- `unique`
+
+### Unique constraints
+
+`get_unique_constraints(connection, table_name, schema=None, **kw)` returns named column groups.
+
+### Check constraints
+
+`get_check_constraints(connection, table_name, schema=None, **kw)` returns non-null check SQL text.
+
+## Sequence reflection
+
+### `has_sequence(connection, sequence_name, schema=None, **kw)`
+
+Implemented via `all_sequences` count lookup.
+
+### `get_sequence_names()` and `get_sequence_range()`
+
+These methods are not overridden in this dialect module. If your workflow depends on them, use explicit SQL against Tibero metadata or test SQLAlchemy default behavior in your version.
+
+## Additional object existence checks
+
+- `has_table(connection, table_name, schema=None, **kw)` checks both tables and views.
+- `has_index(connection, table_name, index_name, schema=None)` checks `all_indexes`.
+
+## Reflection flow
+
+```mermaid
+flowchart TD
+    i[Inspector call] --> s[_effective_schema]
+    s --> q[Run metadata query on ALL_* or USER_* views]
+    q --> r[_row_get extracts row values]
+    r --> t[_resolve_column_type / group constraints]
+    t --> out[SQLAlchemy reflection dictionaries]
+```
+
+!!! note "Uppercase object matching"
+    Reflection SQL uppercases table/view/sequence names before filtering.
+
+!!! warning "Unknown type fallback"
+    Unmapped `DATA_TYPE` values become `NULLTYPE`, which can impact autogeneration and comparisons.
+
+---
+
+# DDL Generation
+
+DDL generation is handled by `TiberoDDLCompiler` and `TiberoTypeCompiler`.
+
+## CREATE TABLE column specification
+
+`TiberoDDLCompiler.get_column_specification()` builds each column as:
+
+1. Formatted column name
+2. Compiled Tibero type
+3. `NOT NULL` when applicable
+4. Identity or default clause
+
+Identity behavior:
+
+- If column is the table autoincrement column and has no server default, emit:
+
+```sql
+GENERATED ALWAYS AS IDENTITY
+```
+
+- Otherwise, emit explicit `DEFAULT <expr>` if present.
+
+## Table comments
+
+Supported comment methods:
+
+- `post_create_table(table)` appends `COMMENT ON TABLE ...`
+- `visit_set_table_comment(create, **kw)`
+- `visit_drop_table_comment(drop, **kw)`
+
+Example emitted SQL:
+
+```sql
+COMMENT ON TABLE users IS 'Application users'
+```
+
+## Column comments
+
+`visit_set_column_comment(create, **kw)` emits:
+
+```sql
+COMMENT ON COLUMN users.name IS 'Display name'
+```
+
+## Sequences
+
+The dialect advertises `supports_sequences = True` and `sequences_optional = True`, so SQLAlchemy sequence constructs are supported.
+
+## DDL compilation flow
+
+```mermaid
+flowchart LR
+    model[Table/Column metadata] --> ddl[TiberoDDLCompiler]
+    ddl --> typec[TiberoTypeCompiler]
+    typec --> sql[CREATE/ALTER/COMMENT SQL]
+    sql --> exec[DB-API execution via engine]
+```
+
+!!! note "Comments are emitted separately"
+    `inline_comments = False`, so comments are produced as standalone `COMMENT ON` statements.
+
+!!! warning "Identity condition is strict"
+    Identity SQL is only emitted for SQLAlchemy's detected autoincrement column with no explicit server default.
+
+---
+
+# Limitations and Workarounds
+
+This page lists currently declared limitations in `TiberoDialect` and compiler behavior.
+
+## SQL RETURNING is disabled
+
+Dialect flags:
+
+- `insert_returning = False`
+- `update_returning = False`
+- `delete_returning = False`
+
+Workarounds:
+
+- Execute DML, then query the changed row(s) with a follow-up `SELECT`.
+- For generated identifiers, rely on sequence usage or DB-API `lastrowid` when available.
+
+## No native BOOLEAN type
+
+- `supports_native_boolean = False`
+- `BOOLEAN` compiles to `NUMBER(1)`.
+
+Workarounds:
+
+- Store booleans as `0/1` (`NUMBER(1)`).
+- Add check constraints such as `CHECK (flag IN (0, 1))`.
+
+## No native ENUM type
+
+- `supports_native_enum = False`
+
+Workarounds:
+
+- Use `String`/`VARCHAR2` with an explicit check constraint.
+- Enforce allowed values in application logic.
+
+## Empty INSERT unsupported
+
+- `supports_empty_insert = False`
+
+Workarounds:
+
+- Always provide at least one explicit column/value in INSERT statements.
+- Use server defaults with explicit column lists where possible.
+
+## SQL feature gaps declared by flags
+
+- `supports_default_values = False`
+- `supports_default_metavalue = False`
+- `supports_is_distinct_from = False`
+
+Workarounds:
+
+- Prefer explicit values/default expressions.
+- Replace `IS DISTINCT FROM` logic with equivalent null-safe predicates.
+
+## Reflection caveat for unknown types
+
+Unknown reflected column types map to `sqltypes.NULLTYPE`.
+
+Workaround:
+
+- Add/extend `ischema_names` mapping in the dialect when introducing new Tibero data types.
+
+## Supported vs unsupported overview
+
+```mermaid
+flowchart TD
+    subgraph Supported
+      s1[Sequences]
+      s2[Comments]
+      s3[Identity columns]
+      s4[Multi-row insert]
+    end
+    subgraph Unsupported_or_Limited
+      u1[RETURNING]
+      u2[Native BOOLEAN]
+      u3[Native ENUM]
+      u4[Empty INSERT]
+      u5[IS DISTINCT FROM]
+    end
+```
+
+!!! warning "Model with constraints"
+    Because native boolean/enum support is disabled, schema-level constraints are important for data integrity.
+
+---
+
+# API Reference
+
+This reference documents the public API surface in `sqlalchemy_pytibero`.
+
+## Dialect class
+
+## `TiberoDialect`
+
+Module: `sqlalchemy_pytibero.dialect`
+
+### Key class attributes
+
+| Attribute | Value |
+|---|---|
+| `name` | `"tibero"` |
+| `driver` | `"pytibero"` |
+| `default_paramstyle` | `"qmark"` |
+| `statement_compiler` | `TiberoCompiler` |
+| `ddl_compiler` | `TiberoDDLCompiler` |
+| `type_compiler` | `TiberoTypeCompiler` |
+| `preparer` | `TiberoIdentifierPreparer` |
+| `execution_ctx_cls` | `TiberoExecutionContext` |
+
+### Public methods
+
+| Method | Purpose |
+|---|---|
+| `import_dbapi()` | Imports and returns `pytibero`. |
+| `dbapi()` | Alias to `import_dbapi()`. |
+| `create_connect_args(url)` | Builds DB-API connection kwargs with Tibero defaults. |
+| `on_connect()` | Returns a connection initializer (`autocommit=False`, optional isolation). |
+| `get_isolation_level(dbapi_conn)` | Reads current session isolation via `SYS_CONTEXT`. |
+| `get_isolation_level_values()` | Returns supported values: `READ COMMITTED`, `SERIALIZABLE`. |
+| `set_isolation_level(dbapi_conn, level)` | Applies isolation level with validation. |
+| `reset_isolation_level(dbapi_conn)` | Resets to `READ COMMITTED`. |
+| `_get_server_version_info(connection)` | Parses version tuple from `V$VERSION`. |
+| `_get_default_schema_name(connection)` | Returns current schema from `SYS_CONTEXT`. |
+| `get_table_names(...)` | Reflects table names. |
+| `get_view_names(...)` | Reflects view names. |
+| `get_view_definition(...)` | Reflects a view definition. |
+| `get_columns(...)` | Reflects table columns and resolved types. |
+| `get_pk_constraint(...)` | Reflects primary key metadata. |
+| `get_foreign_keys(...)` | Reflects foreign keys. |
+| `get_indexes(...)` | Reflects indexes. |
+| `get_unique_constraints(...)` | Reflects unique constraints. |
+| `get_check_constraints(...)` | Reflects check constraints. |
+| `get_table_comment(...)` | Reflects table comment. |
+| `get_schema_names(connection, **kw)` | Returns schema usernames. |
+| `has_table(...)` | Checks table or view existence. |
+| `has_index(...)` | Checks index existence. |
+| `has_sequence(...)` | Checks sequence existence. |
+| `is_disconnect(e, connection, cursor)` | Heuristic disconnect detection. |
+| `do_ping(dbapi_connection)` | Executes `SELECT 1 FROM DUAL` health check. |
+
+### Key method parameters
+
+#### `create_connect_args(url)`
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `url` | SQLAlchemy URL | Required. Raises `ValueError` when `None`. |
+
+#### `set_isolation_level(dbapi_conn, level)`
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `dbapi_conn` | DB-API connection | Must provide `cursor()`. |
+| `level` | `str` | Case-insensitive input; must normalize to supported values. |
+
+## SQL compiler classes
+
+## `TiberoCompiler`
+
+Module: `sqlalchemy_pytibero.compiler`
+
+Important visit/override methods:
+
+- `visit_sysdate_func()` -> `SYSDATE`
+- `visit_systimestamp_func()` -> `SYSTIMESTAMP`
+- `visit_dual_func()` -> `DUAL`
+- `visit_nvl_func()` -> `NVL(...)`
+- `default_from()` -> ` FROM DUAL`
+- `visit_cast()`
+- `render_literal_value()` (escapes backslashes)
+- `get_select_precolumns()`
+- `visit_join()`
+- `for_update_clause()`
+- `limit_clause()` (`OFFSET`/`FETCH FIRST`)
+
+## `TiberoDDLCompiler`
+
+Important methods:
+
+- `get_column_specification()`
+- `post_create_table()`
+- `visit_set_table_comment()`
+- `visit_drop_table_comment()`
+- `visit_set_column_comment()`
+
+## `TiberoTypeCompiler`
+
+Supports Tibero-oriented type rendering methods, including:
+
+- Numeric: `visit_NUMERIC`, `visit_NUMBER`, `visit_DECIMAL`, `visit_FLOAT`
+- Float variants: `visit_BINARY_FLOAT`, `visit_BINARY_DOUBLE`
+- Integer: `visit_SMALLINT`, `visit_INTEGER`, `visit_BIGINT`
+- Character/Large text: `visit_VARCHAR2`, `visit_CHAR`, `visit_NCHAR`, `visit_NVARCHAR2`, `visit_CLOB`, `visit_NCLOB`, `visit_LONG`
+- Binary: `visit_BLOB`, `visit_RAW`, `visit_LONG_RAW`
+- Date/time/interval: `visit_DATE`, `visit_TIMESTAMP`, `visit_INTERVAL_YEAR_TO_MONTH`, `visit_INTERVAL_DAY_TO_SECOND`
+- Generic coercions: `visit_BOOLEAN`, `visit_large_binary`, `visit_text`, `visit_datetime`
+
+## Base classes
+
+## `TiberoIdentifierPreparer`
+
+Module: `sqlalchemy_pytibero.base`
+
+- Uses Tibero reserved words set for quoting decisions.
+- Provides `_quote_free_identifiers(*ids)` helper.
+
+## `TiberoExecutionContext`
+
+Module: `sqlalchemy_pytibero.base`
+
+- `should_autocommit_text(statement)` checks DML/DDL patterns.
+- `get_lastrowid()` returns `cursor.lastrowid` when available, otherwise `None`.
+
+## Type classes (`sqlalchemy_pytibero.types`)
+
+- `NUMBER`, `NUMERIC`, `DECIMAL`, `FLOAT`, `BINARY_FLOAT`, `BINARY_DOUBLE`
+- `SMALLINT`, `INTEGER`, `BIGINT`
+- `VARCHAR2`, `CHAR`, `NCHAR`, `NVARCHAR2`
+- `CLOB`, `NCLOB`, `BLOB`
+- `DATE`, `TIMESTAMP`
+- `INTERVAL_YEAR_TO_MONTH`, `INTERVAL_DAY_TO_SECOND`
+- `RAW`, `LONG_RAW`, `LONG`, `ROWID`
+
+## Class hierarchy overview
+
+```mermaid
+classDiagram
+    class DefaultDialect
+    class TiberoDialect
+    class SQLCompiler
+    class DDLCompiler
+    class GenericTypeCompiler
+    class IdentifierPreparer
+    class DefaultExecutionContext
+
+    DefaultDialect <|-- TiberoDialect
+    SQLCompiler <|-- TiberoCompiler
+    DDLCompiler <|-- TiberoDDLCompiler
+    GenericTypeCompiler <|-- TiberoTypeCompiler
+    IdentifierPreparer <|-- TiberoIdentifierPreparer
+    DefaultExecutionContext <|-- TiberoExecutionContext
+
+    TiberoDialect --> TiberoCompiler : statement_compiler
+    TiberoDialect --> TiberoDDLCompiler : ddl_compiler
+    TiberoDialect --> TiberoTypeCompiler : type_compiler
+    TiberoDialect --> TiberoIdentifierPreparer : preparer
+    TiberoDialect --> TiberoExecutionContext : execution_ctx_cls
+```
+
+!!! note "Version"
+    Current package version in `__init__.py` is `0.1.0`.
+
+---
+
+# Development Guide
+
+## Clone and setup
+
+```bash
+git clone https://github.com/yeongseon/sqlalchemy-pytibero.git
+cd sqlalchemy-pytibero
+python -m venv .venv
+source .venv/bin/activate
+```
+
+## Install development dependencies
+
+Defined in `pyproject.toml` under `[project.optional-dependencies].dev`:
+
+- `pytest>=7.0`
+- `pytest-cov`
+- `ruff==0.15.6`
+
+Install:
+
+```bash
+pip install -e .
+pip install -e ".[dev,pytibero]"
+```
+
+## Run tests
+
+```bash
+pytest
+```
+
+Current test configuration:
+
+- `testpaths = ["test"]`
+- `collect_ignore_glob = ["test/oracle_compat/*"]`
+
+There are currently no dedicated dialect-integration tests in this repository; `oracle_compat` tests are excluded.
+
+## Lint and style
+
+Ruff is configured with:
+
+- line length: `100`
+- target version: `py310`
+
+Run lint checks:
+
+```bash
+ruff check .
+```
+
+## Contributing workflow
+
+1. Create a feature branch.
+2. Implement changes with focused commits.
+3. Run `ruff check .` and `pytest`.
+4. Update documentation when behavior changes.
+5. Push branch and open a pull request.
+
+## Development workflow diagram
+
+```mermaid
+flowchart LR
+    fork[Branch from main/docs branch] --> code[Implement changes]
+    code --> lint[ruff check .]
+    lint --> test[pytest]
+    test --> docs[Update docs]
+    docs --> push[git push]
+    push --> pr[Open PR]
+```
+
+!!! note "Target compatibility"
+    Package metadata declares Python `>=3.10`.
+
+!!! warning "Driver dependency"
+    If you run integration-style checks, ensure `pytibero` is installed and a Tibero instance is reachable.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,23 @@
+# sqlalchemy-pytibero
+
+> SQLAlchemy 2.0 dialect for the Tibero database, enabling ORM queries, schema reflection, DDL generation, and Tibero-specific type mappings.
+
+sqlalchemy-pytibero provides a full SQLAlchemy 2.0 dialect for Tibero RDBMS. It supports connection pooling, ORM operations, raw SQL, DDL reflection, and custom type mappings via the pytibero driver. Default connection: `tibero://tibero:@localhost:8629/tibero`.
+
+## Core Documentation
+
+- [Quick Start](https://yeongseon.github.io/sqlalchemy-pytibero/quickstart/): Installation, first ORM model, basic CRUD operations
+- [Connection Guide](https://yeongseon.github.io/sqlalchemy-pytibero/connection/): URL formats, engine options, pooling, timeouts
+- [Dialect Features](https://yeongseon.github.io/sqlalchemy-pytibero/dialect-features/): Tibero-specific SQL features, function support, hints
+- [Type Mapping](https://yeongseon.github.io/sqlalchemy-pytibero/types/): Tibero-to-SQLAlchemy type conversion, custom types
+- [API Reference](https://yeongseon.github.io/sqlalchemy-pytibero/api-reference/): Dialect, compiler, type classes
+
+## Reference
+
+- [Schema Reflection](https://yeongseon.github.io/sqlalchemy-pytibero/reflection/): Table introspection, inspector, metadata reflection
+- [DDL Generation](https://yeongseon.github.io/sqlalchemy-pytibero/ddl/): CREATE TABLE, indexes, constraints, Tibero-specific DDL
+- [Limitations](https://yeongseon.github.io/sqlalchemy-pytibero/limitations/): Known limitations, unsupported features, workarounds
+
+## Optional
+
+- [Development Guide](https://yeongseon.github.io/sqlalchemy-pytibero/development/): Contributing, testing, release process

--- a/scripts/generate_llms_full.py
+++ b/scripts/generate_llms_full.py
@@ -1,0 +1,38 @@
+"""Generate docs/llms-full.txt by concatenating documentation Markdown files."""
+from __future__ import annotations
+
+import pathlib
+
+# Ordered list of doc files to include
+DOC_FILES: list[str] = [
+    "index.md",
+    "quickstart.md",
+    "connection.md",
+    "dialect-features.md",
+    "types.md",
+    "reflection.md",
+    "ddl.md",
+    "limitations.md",
+    "api-reference.md",
+    "development.md",
+]
+
+
+def main() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    docs_dir = repo_root / "docs"
+    output = docs_dir / "llms-full.txt"
+
+    sections: list[str] = []
+    for filename in DOC_FILES:
+        filepath = docs_dir / filename
+        if filepath.exists():
+            content = filepath.read_text(encoding="utf-8").strip()
+            sections.append(content)
+
+    output.write_text("\n\n---\n\n".join(sections) + "\n", encoding="utf-8")
+    print(f"Generated {output} ({output.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `docs/llms.txt` — curated documentation index following the [llms.txt specification](https://llmstxt.org/)
- Add `docs/llms-full.txt` — auto-generated concatenation of all documentation for full-context LLM ingestion
- Add `scripts/generate_llms_full.py` — generation script for llms-full.txt
- Update `docs.yml` workflow to regenerate llms-full.txt before each docs build

## Why

LLM coding assistants (Cursor, Copilot, etc.) benefit from structured documentation at `/llms.txt`. This follows the emerging standard adopted by FastAPI, Pydantic, Dask, and Google ADK.

Once deployed, documentation will be available at:
- https://yeongseon.github.io/sqlalchemy-pytibero/llms.txt
- https://yeongseon.github.io/sqlalchemy-pytibero/llms-full.txt